### PR TITLE
Issue#14: Add support for adding jars to Executor ClassPath using Spark property "spark.executor.extraClassPath" 

### DIFF
--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.scheduler.cluster.nomad
 
+import java.net.URI
+
 import com.hashicorp.nomad.apimodel.Task
 
 import org.apache.spark.{SecurityManager, SparkConf}
@@ -80,6 +82,14 @@ private[spark] object ExecutorTask
     // Have the executor give its allocation ID as its log URL
     // The driver will lookup the actual log URLs
     task.addEnv("SPARK_LOG_URL_" + LOG_KEY_FOR_ALLOC_ID, "${NOMAD_ALLOC_ID}")
+
+    if (conf.getOption("spark.jars").nonEmpty) {
+      task.addEnv("SPARK_EXECUTOR_CLASSPATH", conf.getOption("spark.jars").get
+        .split(",").map(jarLocation => new URI(jarLocation).getPath).mkString(":"))
+    }
+    if (conf.getOption("spark.executor.extraClassPath").nonEmpty) {
+      task.addEnv("SPARK_EXECUTOR_CLASSPATH", conf.getOption("spark.executor.extraClassPath").get)
+    }
 
     task
   }

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.scheduler.cluster.nomad
 
+import java.net.URI
 import com.hashicorp.nomad.apimodel.Task
 
 import org.apache.spark.{SecurityManager, SparkConf}
@@ -80,6 +81,14 @@ private[spark] object ExecutorTask
     // Have the executor give its allocation ID as its log URL
     // The driver will lookup the actual log URLs
     task.addEnv("SPARK_LOG_URL_" + LOG_KEY_FOR_ALLOC_ID, "${NOMAD_ALLOC_ID}")
+
+    if (conf.getOption("spark.jars").nonEmpty) {
+      task.addEnv("SPARK_EXECUTOR_CLASSPATH", conf.getOption("spark.jars").get
+        .split(",").map(jarLocation => new URI(jarLocation).getPath).mkString(":"))
+    }
+    if (conf.getOption("spark.executor.extraClassPath").nonEmpty) {
+      task.addEnv("SPARK_EXECUTOR_CLASSPATH", conf.getOption("spark.executor.extraClassPath").get)
+    }
 
     task
   }

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.scheduler.cluster.nomad
 
-import java.net.URI
-
 import com.hashicorp.nomad.apimodel.Task
 
 import org.apache.spark.{SecurityManager, SparkConf}
@@ -83,10 +81,6 @@ private[spark] object ExecutorTask
     // The driver will lookup the actual log URLs
     task.addEnv("SPARK_LOG_URL_" + LOG_KEY_FOR_ALLOC_ID, "${NOMAD_ALLOC_ID}")
 
-    if (conf.getOption("spark.jars").nonEmpty) {
-      task.addEnv("SPARK_EXECUTOR_CLASSPATH", conf.getOption("spark.jars").get
-        .split(",").map(jarLocation => new URI(jarLocation).getPath).mkString(":"))
-    }
     if (conf.getOption("spark.executor.extraClassPath").nonEmpty) {
       task.addEnv("SPARK_EXECUTOR_CLASSPATH", conf.getOption("spark.executor.extraClassPath").get)
     }

--- a/resource-managers/nomad/src/test/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTaskTest.scala
+++ b/resource-managers/nomad/src/test/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTaskTest.scala
@@ -134,7 +134,8 @@ class ExecutorTaskTest extends SparkFunSuite {
     }
   }
 
-  test("verify whether input conf 'spark.jars' is properly parsed, and set to env SPARK_EXECUTOR_CLASSPATH") {
+  test("verify whether input conf 'spark.jars' is properly parsed," +
+    " and set to env SPARK_EXECUTOR_CLASSPATH") {
     val commonConf = SparkNomadJob.CommonConf(appName = "app-name-123",
       appId = "app-id-123",
       dockerImage = None,
@@ -142,7 +143,7 @@ class ExecutorTaskTest extends SparkFunSuite {
       sparkDistribution = Some(new URI("local:///spark")),
       preventOverwrite = true
     )
-    val sparkConf  = new SparkConf()
+    val sparkConf = new SparkConf()
     val sparkJars = "local:///hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar," +
       "local:///hadoop-2.8.5/share/hadoop/tools/lib/aws-java-sdk-core-1.10.6.jar"
     sparkConf.set("spark.jars", sparkJars)
@@ -159,12 +160,14 @@ class ExecutorTaskTest extends SparkFunSuite {
       driverUrl = "driver/url/3421")
 
     val actualSparkExecutorClasspath = nomadTask.getEnv.get("SPARK_EXECUTOR_CLASSPATH")
-    val expectedSparkExecutorClasspath = "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:" +
+    val expectedSparkExecutorClasspath =
+      "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:" +
       "/hadoop-2.8.5/share/hadoop/tools/lib/aws-java-sdk-core-1.10.6.jar"
     assert(expectedSparkExecutorClasspath == actualSparkExecutorClasspath)
   }
 
-  test("verify whether input conf 'spark.executor.extraClassPath' is set to env SPARK_EXECUTOR_CLASSPATH") {
+  test("verify whether input conf 'spark.executor.extraClassPath' is set to" +
+    " env SPARK_EXECUTOR_CLASSPATH") {
     val commonConf = SparkNomadJob.CommonConf(appName = "app-name-123",
       appId = "app-id-123",
       dockerImage = None,
@@ -172,7 +175,7 @@ class ExecutorTaskTest extends SparkFunSuite {
       sparkDistribution = Some(new URI("local:///spark")),
       preventOverwrite = true
     )
-    val sparkConf  = new SparkConf()
+    val sparkConf = new SparkConf()
     val sparkExtraClasspath = "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:" +
       "/hadoop-2.8.5/share/hadoop/tools/lib/aws-java-sdk-core-1.10.6.jar"
     sparkConf.set("spark.executor.extraClassPath", sparkExtraClasspath)
@@ -190,12 +193,14 @@ class ExecutorTaskTest extends SparkFunSuite {
       driverUrl = "driver/url/3421")
 
     val actualSparkExecutorClasspath = nomadTask.getEnv.get("SPARK_EXECUTOR_CLASSPATH")
-    val expectedSparkExecutorClasspath = "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:" +
+    val expectedSparkExecutorClasspath =
+      "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:" +
       "/hadoop-2.8.5/share/hadoop/tools/lib/aws-java-sdk-core-1.10.6.jar"
     assert(expectedSparkExecutorClasspath == actualSparkExecutorClasspath)
   }
 
-  test("verify whether input conf 'spark.executor.extraClassPath' overrides values of 'spark.jars' in Env SPARK_EXECUTOR_CLASSPATH") {
+  test("verify whether input conf 'spark.executor.extraClassPath'" +
+    " overrides values of 'spark.jars' in Env SPARK_EXECUTOR_CLASSPATH") {
     val commonConf = SparkNomadJob.CommonConf(appName = "app-name-123",
       appId = "app-id-123",
       dockerImage = None,
@@ -203,7 +208,7 @@ class ExecutorTaskTest extends SparkFunSuite {
       sparkDistribution = Some(new URI("local:///spark")),
       preventOverwrite = true
     )
-    val sparkConf  = new SparkConf()
+    val sparkConf = new SparkConf()
     val sparkJars = "local:///hadoop-2.8.5/share/hadoop/tools/lib/hadoop-testing-2.8.5.jar," +
       "local:///hadoop-2.8.5/share/hadoop/tools/lib/aws-testing-1.10.6.jar"
     sparkConf.set("spark.jars", sparkJars)
@@ -225,7 +230,8 @@ class ExecutorTaskTest extends SparkFunSuite {
       driverUrl = "driver/url/3421")
 
     val actualSparkExecutorClasspath = nomadTask.getEnv.get("SPARK_EXECUTOR_CLASSPATH")
-    val expectedSparkExecutorClasspath = "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:" +
+    val expectedSparkExecutorClasspath =
+      "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:" +
       "/hadoop-2.8.5/share/hadoop/tools/lib/aws-java-sdk-core-1.10.6.jar"
     assert(expectedSparkExecutorClasspath == actualSparkExecutorClasspath)
   }

--- a/resource-managers/nomad/src/test/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTaskTest.scala
+++ b/resource-managers/nomad/src/test/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTaskTest.scala
@@ -147,7 +147,6 @@ class ExecutorTaskTest extends SparkFunSuite {
     val sparkExtraClasspath = "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:" +
       "/hadoop-2.8.5/share/hadoop/tools/lib/aws-java-sdk-core-1.10.6.jar"
     sparkConf.set("spark.executor.extraClassPath", sparkExtraClasspath)
-    sparkConf.set("spark.driver.extraClassPath", sparkExtraClasspath)
     val nomadTask = new Task()
 
     ExecutorTask.configure(jobConf = commonConf,

--- a/resource-managers/nomad/src/test/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTaskTest.scala
+++ b/resource-managers/nomad/src/test/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTaskTest.scala
@@ -134,38 +134,6 @@ class ExecutorTaskTest extends SparkFunSuite {
     }
   }
 
-  test("verify whether input conf 'spark.jars' is properly parsed," +
-    " and set to env SPARK_EXECUTOR_CLASSPATH") {
-    val commonConf = SparkNomadJob.CommonConf(appName = "app-name-123",
-      appId = "app-id-123",
-      dockerImage = None,
-      dockerAuth = None,
-      sparkDistribution = Some(new URI("local:///spark")),
-      preventOverwrite = true
-    )
-    val sparkConf = new SparkConf()
-    val sparkJars = "local:///hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar," +
-      "local:///hadoop-2.8.5/share/hadoop/tools/lib/aws-java-sdk-core-1.10.6.jar"
-    sparkConf.set("spark.jars", sparkJars)
-    val nomadTask = new Task()
-
-    ExecutorTask.configure(jobConf = commonConf,
-      conf = sparkConf,
-      task = nomadTask,
-      shuffleServicePortPlaceholder = None)
-
-    ExecutorTask.addDriverArguments(jobConf = commonConf,
-      conf = sparkConf,
-      task = nomadTask,
-      driverUrl = "driver/url/3421")
-
-    val actualSparkExecutorClasspath = nomadTask.getEnv.get("SPARK_EXECUTOR_CLASSPATH")
-    val expectedSparkExecutorClasspath =
-      "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:" +
-      "/hadoop-2.8.5/share/hadoop/tools/lib/aws-java-sdk-core-1.10.6.jar"
-    assert(expectedSparkExecutorClasspath == actualSparkExecutorClasspath)
-  }
-
   test("verify whether input conf 'spark.executor.extraClassPath' is set to" +
     " env SPARK_EXECUTOR_CLASSPATH") {
     val commonConf = SparkNomadJob.CommonConf(appName = "app-name-123",
@@ -180,43 +148,6 @@ class ExecutorTaskTest extends SparkFunSuite {
       "/hadoop-2.8.5/share/hadoop/tools/lib/aws-java-sdk-core-1.10.6.jar"
     sparkConf.set("spark.executor.extraClassPath", sparkExtraClasspath)
     sparkConf.set("spark.driver.extraClassPath", sparkExtraClasspath)
-    val nomadTask = new Task()
-
-    ExecutorTask.configure(jobConf = commonConf,
-      conf = sparkConf,
-      task = nomadTask,
-      shuffleServicePortPlaceholder = None)
-
-    ExecutorTask.addDriverArguments(jobConf = commonConf,
-      conf = sparkConf,
-      task = nomadTask,
-      driverUrl = "driver/url/3421")
-
-    val actualSparkExecutorClasspath = nomadTask.getEnv.get("SPARK_EXECUTOR_CLASSPATH")
-    val expectedSparkExecutorClasspath =
-      "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:" +
-      "/hadoop-2.8.5/share/hadoop/tools/lib/aws-java-sdk-core-1.10.6.jar"
-    assert(expectedSparkExecutorClasspath == actualSparkExecutorClasspath)
-  }
-
-  test("verify whether input conf 'spark.executor.extraClassPath'" +
-    " overrides values of 'spark.jars' in Env SPARK_EXECUTOR_CLASSPATH") {
-    val commonConf = SparkNomadJob.CommonConf(appName = "app-name-123",
-      appId = "app-id-123",
-      dockerImage = None,
-      dockerAuth = None,
-      sparkDistribution = Some(new URI("local:///spark")),
-      preventOverwrite = true
-    )
-    val sparkConf = new SparkConf()
-    val sparkJars = "local:///hadoop-2.8.5/share/hadoop/tools/lib/hadoop-testing-2.8.5.jar," +
-      "local:///hadoop-2.8.5/share/hadoop/tools/lib/aws-testing-1.10.6.jar"
-    sparkConf.set("spark.jars", sparkJars)
-    val sparkExtraClasspath = "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:" +
-      "/hadoop-2.8.5/share/hadoop/tools/lib/aws-java-sdk-core-1.10.6.jar"
-    sparkConf.set("spark.executor.extraClassPath", sparkExtraClasspath)
-    sparkConf.set("spark.driver.extraClassPath", sparkExtraClasspath)
-
     val nomadTask = new Task()
 
     ExecutorTask.configure(jobConf = commonConf,


### PR DESCRIPTION
nomad-spark PR Summary
==============================

Issue#14: Add support for adding jars to Executor ClassPath using Spark property"spark.executor.extraClassPath" 

Additional Details
==============================

**Logic:** The values of spark property `spark.executor.extraClassPath` is set to a special Env variable `SPARK_EXECUTOR_CLASSPATH` in the Job Spec, and submitted to Nomad.

While the Executor Program is executed, `SparkClassCommandBuilder` extracts the value from the Env Variable `SPARK_EXECUTOR_CLASSPATH`, and adds to Classpath (-cp), and runs the `NomadExecutorBackend` process.

https://github.com/ExpediaGroup/nomad-spark/blob/nomad-spark-2.4.3/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java#L84
https://github.com/ExpediaGroup/nomad-spark/blob/nomad-spark-2.4.3/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java#L103

Checklist
==============================

Testing
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have manually verified that my code changes do the right thing.
* [x] I have run all tests and verified that my changes do not introduce any regressions.
* [x] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions.
* [x] I have tested my code changes locally or against a cluster using an example Spark project.
* [x] Is the PR raised against branch ExpediaGroup:nomad-spark-2.4.3?

Documentation
-------------------------

"N/A - no code changes"