### PR TITLE
[CD] Changing order of manual workflow (2.4.3)

### DIFF
--- a/.github/workflows/build-nomad-spark-distro.yaml
+++ b/.github/workflows/build-nomad-spark-distro.yaml
@@ -1,11 +1,11 @@
-name: Build and Test Nomad-Spark Distribution
+name: Cut a Tag
 
 on: [workflow_dispatch]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Tag/Build/Test
+    name: Build/Test/Create Tag
 
     steps:
       - uses: actions/checkout@v2
@@ -13,10 +13,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: '1.8'
-      - name: Cut Tag from Branch
-        run: |
-          export VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          git tag v$VERSION-nomad-0.8.6-$(date +'%Y%m%d')
       - name: Build Spark Distribution
         run: ./dev/make-distribution.sh --name hadoop-2.7-nomad-0.8.6-expediagroup-$(date +'%Y%m%d') --pip --tgz -Phadoop-2.7 -Dhadoop.version=2.7.3 -Phive -Phive-thriftserver -Pnomad
       - name: Test Distribution
@@ -25,3 +21,7 @@ jobs:
           tar -xvf /home/runner/work/nomad-spark/nomad-spark/spark-$VERSION-bin-hadoop-2.7-nomad-0.8.6-expediagroup-$(date +'%Y%m%d').tgz
           export SPARK_HOME=/home/runner/work/nomad-spark/nomad-spark/spark-$VERSION-bin-hadoop-2.7-nomad-0.8.6-expediagroup-$(date +'%Y%m%d')
           $SPARK_HOME/bin/spark-submit --class org.apache.spark.examples.JavaSparkPi --master local --conf spark.executor.instances=1 --conf spark.nomad.sparkDistribution=local:///spark $SPARK_HOME/examples/jars/spark-examples*.jar
+      - name: Cut Tag from Branch
+        run: |
+          export VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          git tag v$VERSION-nomad-0.8.6-$(date +'%Y%m%d')


### PR DESCRIPTION
nomad-spark PR Summary
==============================

This PR updates the existing manual workflow to cut after building/testing distribution.

Checklist
==============================

Testing
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have manually verified that my code changes do the right thing.
* [ ] I have run all tests and verified that my changes do not introduce any regressions.
* [ ] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions.
* [ ] I have tested my code changes locally or against a cluster using an example Spark project.
* [x] Is the PR raised against branch ExpediaGroup:nomad-spark-2.4.3?

Documentation
-------------------------

N/A - no code changes