### PR TITLE
Jars of property spark.driver.extraClassPath should precede the applicationJar in "--driver-class-path"

### DIFF
--- a/.github/workflows/mvn-branch-ci.yaml
+++ b/.github/workflows/mvn-branch-ci.yaml
@@ -68,7 +68,7 @@ jobs:
         env:
           MAVEN_OPTS: "-Xmx3g -XX:ReservedCodeCacheSize=1024m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
           MAVEN_CLI_OPTS: "--no-transfer-progress"
-        run: ./build/mvn $MAVEN_CLI_OPTS -Pnomad -pl :spark-nomad-test-apps_2.11,:spark-nomad_2.11 -DwildcardSuites=org.apache.spark.scheduler.cluster.nomad.ExecutorTaskTest clean install
+        run: ./build/mvn $MAVEN_CLI_OPTS -Pnomad -pl :spark-nomad-test-apps_2.11,:spark-nomad_2.11 -DwildcardSuites=org.apache.spark.scheduler.cluster.nomad.ExecutorTaskTest,org.apache.spark.scheduler.cluster.nomad.DriverTaskTest clean install
       - name: Build Spark GraphX/MLLib/Streaming Modules
         env:
           MAVEN_OPTS: "-Xmx3g -XX:ReservedCodeCacheSize=1024m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/DriverTask.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/DriverTask.scala
@@ -107,7 +107,7 @@ private[spark] object DriverTask extends SparkNomadTaskType("driver", "driver", 
       }
 
     val driverClassPath =
-      (additionalJarUrls ++ conf.getOption(SparkLauncher.DRIVER_EXTRA_CLASSPATH))
+      (conf.getOption(SparkLauncher.DRIVER_EXTRA_CLASSPATH) ++ additionalJarUrls)
         .map(j => new URI(j).getPath).mkString(":")
 
     val submitOptions: Seq[String] = (

--- a/resource-managers/nomad/src/test/scala/org/apache/spark/scheduler/cluster/nomad/DriverTaskTest.scala
+++ b/resource-managers/nomad/src/test/scala/org/apache/spark/scheduler/cluster/nomad/DriverTaskTest.scala
@@ -1,17 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.scheduler.cluster.nomad
 
 import java.net.URI
 import java.util
 
 import com.hashicorp.nomad.apimodel.Task
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.nomad.ApplicationRunCommand
 import org.apache.spark.deploy.nomad.NomadClusterModeLauncher.PrimaryJar
-import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.scheduler.cluster.nomad.DriverTask.Parameters
+import org.apache.spark.scheduler.cluster.nomad.SparkNomadJob.CommonConf
 
 class DriverTaskTest extends SparkFunSuite {
 
-  test("Jars of 'spark.driver.extraClassPath' precede ApplicationJar in --driver-class-path") {
-    def buildDriverTaskParameters = {
+  test("Jars of 'spark.driver.extraClassPath' should " +
+    "precede ApplicationJar in --driver-class-path") {
+    def buildDriverTaskArgs() : (CommonConf, SparkConf, Parameters) = {
       val commonConf = SparkNomadJob.CommonConf(appId = "test-driver-classpath-app-id",
         appName = "test-driver-classpath-app",
         dockerImage = Some("dockerhub.com/nomad-spark/spark-2.4.6-bin-hadoop-2.7-nomad-0.8.6:v1"),
@@ -21,8 +42,9 @@ class DriverTaskTest extends SparkFunSuite {
 
       val applicationJarPath = "https://mvn.central.com/spark-examples.jar"
       val sparkConf = new SparkConf()
-      sparkConf.set("spark.driver.extraClassPath", "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar")
-      // "spark.jars" property always get auto-populated with ApplicationJar at SparkSubmit.prepareSubmitEnvironment
+      sparkConf.set("spark.driver.extraClassPath",
+        "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar")
+      // "spark.jars" get auto-populated with ApplicationJar at SparkSubmit.prepareSubmitEnvironment
       sparkConf.set("spark.jars", applicationJarPath)
 
       val parameters = DriverTask.Parameters(ApplicationRunCommand(PrimaryJar(applicationJarPath),
@@ -33,15 +55,19 @@ class DriverTaskTest extends SparkFunSuite {
       (commonConf, sparkConf, parameters)
     }
 
-    val (commonConf: SparkNomadJob.CommonConf, sparkConf: SparkConf, parameters: DriverTask.Parameters) = buildDriverTaskParameters
+    val (commonConf: SparkNomadJob.CommonConf, sparkConf: SparkConf,
+    parameters: Parameters) = buildDriverTaskArgs
     val sparkDriverTask = new Task()
 
     // Build the Nomad JobSpec for DriverTask
     DriverTask.configure(commonConf, sparkConf, sparkDriverTask, parameters)
 
     val driverConfigArgs = sparkDriverTask.getConfig.get("args").asInstanceOf[util.List[String]]
-    assert(true == driverConfigArgs.contains("--driver-class-path=/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:/local/spark-examples.jar"))
-    assert(true == driverConfigArgs.contains("--conf=spark.jars=file:///local/spark-examples.jar"))
+    assert(true == driverConfigArgs.contains(
+      "--driver-class-path=/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:" +
+        "/local/spark-examples.jar"))
+    assert(true == driverConfigArgs.contains(
+      "--conf=spark.jars=file:///local/spark-examples.jar"))
   }
 
 

--- a/resource-managers/nomad/src/test/scala/org/apache/spark/scheduler/cluster/nomad/DriverTaskTest.scala
+++ b/resource-managers/nomad/src/test/scala/org/apache/spark/scheduler/cluster/nomad/DriverTaskTest.scala
@@ -1,0 +1,48 @@
+package org.apache.spark.scheduler.cluster.nomad
+
+import java.net.URI
+import java.util
+
+import com.hashicorp.nomad.apimodel.Task
+import org.apache.spark.deploy.nomad.ApplicationRunCommand
+import org.apache.spark.deploy.nomad.NomadClusterModeLauncher.PrimaryJar
+import org.apache.spark.{SparkConf, SparkFunSuite}
+
+class DriverTaskTest extends SparkFunSuite {
+
+  test("Jars of 'spark.driver.extraClassPath' precede ApplicationJar in --driver-class-path") {
+    def buildDriverTaskParameters = {
+      val commonConf = SparkNomadJob.CommonConf(appId = "test-driver-classpath-app-id",
+        appName = "test-driver-classpath-app",
+        dockerImage = Some("dockerhub.com/nomad-spark/spark-2.4.6-bin-hadoop-2.7-nomad-0.8.6:v1"),
+        dockerAuth = None,
+        sparkDistribution = Some(new URI("local:///spark")),
+        preventOverwrite = true)
+
+      val applicationJarPath = "https://mvn.central.com/spark-examples.jar"
+      val sparkConf = new SparkConf()
+      sparkConf.set("spark.driver.extraClassPath", "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar")
+      // "spark.jars" property always get auto-populated with ApplicationJar at SparkSubmit.prepareSubmitEnvironment
+      sparkConf.set("spark.jars", applicationJarPath)
+
+      val parameters = DriverTask.Parameters(ApplicationRunCommand(PrimaryJar(applicationJarPath),
+        mainClass = "org.examples.SparkPi",
+        arguments = List()),
+        None)
+
+      (commonConf, sparkConf, parameters)
+    }
+
+    val (commonConf: SparkNomadJob.CommonConf, sparkConf: SparkConf, parameters: DriverTask.Parameters) = buildDriverTaskParameters
+    val sparkDriverTask = new Task()
+
+    // Build the Nomad JobSpec for DriverTask
+    DriverTask.configure(commonConf, sparkConf, sparkDriverTask, parameters)
+
+    val driverConfigArgs = sparkDriverTask.getConfig.get("args").asInstanceOf[util.List[String]]
+    assert(true == driverConfigArgs.contains("--driver-class-path=/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:/local/spark-examples.jar"))
+    assert(true == driverConfigArgs.contains("--conf=spark.jars=file:///local/spark-examples.jar"))
+  }
+
+
+}


### PR DESCRIPTION
nomad-spark PR Summary
==============================

Jars of property spark.driver.extraClassPath should precede the applicationJar in `--driver-class-path`

**Current Behavior:**
Lets say, the inputs are
```
"spark.driver.extraClassPath" : "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar"

Application Jar is passed as https://artifactory.com/tpcds-benchmark-fixed-1.0.0-SNAPSHOT.jar"
```
The Nomad DriverTask build the JobSpec config as
```
--driver-class-path=/local/tpcds-benchmark-fixed-1.0.0-SNAPSHOT.jar:/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar
```
This causes version mis-match errors, as the Application Jar may have non-compatible spark dependencies in its Shaded Jar

**Expected & PR Behavior:**
For inputs
```
"spark.driver.extraClassPath" : "/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar"

Application Jar is passed as https://artifactory.com/tpcds-benchmark-fixed-1.0.0-SNAPSHOT.jar"
```
The Nomad DriverTask builds the JobSpec config as
```
--driver-class-path=/hadoop-2.8.5/share/hadoop/tools/lib/hadoop-aws-2.8.5.jar:/local/tpcds-benchmark-fixed-1.0.0-SNAPSHOT.jar
```

Checklist
==============================

Testing
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have manually verified that my code changes do the right thing.
* [x] I have run all tests and verified that my changes do not introduce any regressions.
* [x] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions.
* [x] I have tested my code changes locally or against a cluster using an example Spark project.

Documentation
-------------------------

"N/A - no code changes"