### PR TITLE
Adding support for downscaling with Nomad dynamic allocation

### DIFF
--- a/.github/workflows/build-nomad-spark-distro.yaml
+++ b/.github/workflows/build-nomad-spark-distro.yaml
@@ -14,15 +14,15 @@ jobs:
         with:
           java-version: '1.8'
       - name: Build Spark Distribution
-        run: ./dev/make-distribution.sh --name hadoop-2.7-nomad-0.8.6-expediagroup-$(date +'%Y%m%d') --pip --tgz -Phadoop-2.7 -Dhadoop.version=2.7.3 -Phive -Phive-thriftserver -Pnomad
+        run: ./dev/make-distribution.sh --name hadoop-2.7-nomad-0.9.7-expediagroup-$(date +'%Y%m%d') --pip --tgz -Phadoop-2.7 -Dhadoop.version=2.7.3 -Phive -Phive-thriftserver -Pnomad
       - name: Test Distribution
         run: |
           export VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          tar -xvf /home/runner/work/nomad-spark/nomad-spark/spark-$VERSION-bin-hadoop-2.7-nomad-0.8.6-expediagroup-$(date +'%Y%m%d').tgz
-          export SPARK_HOME=/home/runner/work/nomad-spark/nomad-spark/spark-$VERSION-bin-hadoop-2.7-nomad-0.8.6-expediagroup-$(date +'%Y%m%d')
+          tar -xvf /home/runner/work/nomad-spark/nomad-spark/spark-$VERSION-bin-hadoop-2.7-nomad-0.9.7-expediagroup-$(date +'%Y%m%d').tgz
+          export SPARK_HOME=/home/runner/work/nomad-spark/nomad-spark/spark-$VERSION-bin-hadoop-2.7-nomad-0.9.7-expediagroup-$(date +'%Y%m%d')
           $SPARK_HOME/bin/spark-submit --class org.apache.spark.examples.JavaSparkPi --master local --conf spark.executor.instances=1 --conf spark.nomad.sparkDistribution=local:///spark $SPARK_HOME/examples/jars/spark-examples*.jar
       - name: Cut Tag from Branch
         run: |
           export VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          git tag v$VERSION-nomad-0.8.6-$(date +'%Y%m%d')
-          git push origin v$VERSION-nomad-0.8.6-$(date +'%Y%m%d')
+          git tag v$VERSION-nomad-0.9.7-$(date +'%Y%m%d')
+          git push origin v$VERSION-nomad-0.9.7-$(date +'%Y%m%d')

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -151,8 +151,8 @@ metrics-jvm/3.1.5//metrics-jvm-3.1.5.jar
 minlog/1.3.0//minlog-1.3.0.jar
 netty-all/4.1.47.Final//netty-all-4.1.47.Final.jar
 netty/3.9.9.Final//netty-3.9.9.Final.jar
-nomad-scala-sdk_2.11/0.8.6.1//nomad-scala-sdk_2.11-0.8.6.1.jar
-nomad-sdk/0.8.6.1//nomad-sdk-0.8.6.1.jar
+nomad-scala-sdk_2.11/0.9.7//nomad-scala-sdk_2.11-0.9.7.jar
+nomad-sdk/0.9.7.0//nomad-sdk-0.9.7.0.jar
 objenesis/2.5.1//objenesis-2.5.1.jar
 okhttp/3.12.0//okhttp-3.12.0.jar
 okio/1.15.0//okio-1.15.0.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -152,8 +152,8 @@ metrics-jvm/3.1.5//metrics-jvm-3.1.5.jar
 minlog/1.3.0//minlog-1.3.0.jar
 netty-all/4.1.47.Final//netty-all-4.1.47.Final.jar
 netty/3.9.9.Final//netty-3.9.9.Final.jar
-nomad-scala-sdk_2.11/0.8.6.1//nomad-scala-sdk_2.11-0.8.6.1.jar
-nomad-sdk/0.8.6.1//nomad-sdk-0.8.6.1.jar
+nomad-scala-sdk_2.11/0.9.7//nomad-scala-sdk_2.11-0.9.7.jar
+nomad-sdk/0.9.7.0//nomad-sdk-0.9.7.0.jar
 objenesis/2.5.1//objenesis-2.5.1.jar
 okhttp/3.12.0//okhttp-3.12.0.jar
 okio/1.15.0//okio-1.15.0.jar

--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -170,8 +170,8 @@ mssql-jdbc/6.2.1.jre7//mssql-jdbc-6.2.1.jre7.jar
 netty-all/4.1.47.Final//netty-all-4.1.47.Final.jar
 netty/3.9.9.Final//netty-3.9.9.Final.jar
 nimbus-jose-jwt/4.41.1//nimbus-jose-jwt-4.41.1.jar
-nomad-scala-sdk_2.11/0.8.6.1//nomad-scala-sdk_2.11-0.8.6.1.jar
-nomad-sdk/0.8.6.1//nomad-sdk-0.8.6.1.jar
+nomad-scala-sdk_2.11/0.9.7//nomad-scala-sdk_2.11-0.9.7.jar
+nomad-sdk/0.9.7.0//nomad-sdk-0.9.7.0.jar
 objenesis/2.5.1//objenesis-2.5.1.jar
 okhttp/2.7.5//okhttp-2.7.5.jar
 okhttp/3.12.0//okhttp-3.12.0.jar

--- a/docs/job-scheduling.md
+++ b/docs/job-scheduling.md
@@ -66,7 +66,7 @@ useful if multiple applications share resources in your Spark cluster.
 This feature is disabled by default and available on all coarse-grained cluster managers, i.e.
 [standalone mode](spark-standalone.html), [YARN mode](running-on-yarn.html),
 [Mesos coarse-grained mode](running-on-mesos.html#mesos-run-modes), and
-[Nomad mode](running-on-nomade.html#dynamic-allocation-of-executors).
+[Nomad mode](running-on-nomad.html#dynamic-allocation-of-executors).
 
 ### Configuration and Setup
 

--- a/docs/running-on-nomad.md
+++ b/docs/running-on-nomad.md
@@ -415,21 +415,18 @@ job "template" {
 # Dynamic Allocation of Executors
 
 By default, the Spark application will use a fixed number of executors.
-Setting `spark.dynamicAllocation` to `true` enables Spark to
-add and remove executors during execution depending on the number of Spark tasks scheduled to run.
-As described in [Dynamic Resource Allocation](http://spark.apache.org/docs/latest/job-scheduling.html#configuration-and-setup),
+Setting `spark.dynamicAllocation.enabled` to `true` enables Spark to add and remove executors during 
+execution depending on the number of Spark tasks scheduled to run. As described in [Dynamic Resource Allocation](http://spark.apache.org/docs/latest/job-scheduling.html#configuration-and-setup),
 dynamic allocation requires that `spark.shuffle.service.enabled` be set to `true`.
 
-On Nomad, setting `spark.shuffle.service.enabled` to `true` adds an additional
-shuffle serivce Nomad task to the executors' task group. This results in a
-one-to-one mapping of executors to shuffle services.
-
-When the executor exits, the shuffle service continues running so that it can serve any results produced by the
-executor. Note that due to the way resource allocation works in Nomad,
-the resources allocated to the executor Nomad task aren't freed until the shuffle service
-is also finished, meaning that they will remain allocated until the application has finished.
-This may improve in the future.
-
+On Nomad, setting `spark.shuffle.service.enabled` to `true` configures Spark executors to point to an externally deployed 
+Spark shuffle service, which must be deployed separately from the running Spark job (similarly to the deployment pattern 
+for Spark Standalone or Spark on Mesos).  Executors write their shuffle data to a local directory (`/spark-local-dir` by default, 
+reconfigurable via `spark.local.dir`).  The external shuffle service must be able to read from this directory in order to 
+access and serve shuffle data.  This requires no extra configuration in the shuffle service deployment because 
+executors inform the shuffle service of their local shuffle locations when registering with them. When running
+Spark on Nomad using Docker, this directory must be volume mapped to the Nomad host at a location the shuffle service 
+is able to access.
 
 # Python and R
 

--- a/resource-managers/nomad/pom.xml
+++ b/resource-managers/nomad/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
         <groupId>com.hashicorp.nomad</groupId>
         <artifactId>nomad-testkit</artifactId>
-        <version>0.8.6.1</version>
+        <version>0.9.7.0</version>
         <scope>test</scope>
     </dependency>
 

--- a/resource-managers/nomad/pom.xml
+++ b/resource-managers/nomad/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.hashicorp.nomad</groupId>
       <artifactId>nomad-scala-sdk_${scala.binary.version}</artifactId>
-      <version>0.8.6.1</version>
+      <version>0.9.7</version>
     </dependency>
 
     <dependency>

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
@@ -18,10 +18,9 @@
 package org.apache.spark.scheduler.cluster.nomad
 
 import com.hashicorp.nomad.apimodel.Task
-
-import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.internal.config.EXECUTOR_MEMORY
 import org.apache.spark.util.Utils
+import org.apache.spark.{SecurityManager, SparkConf}
 
 private[spark] object ExecutorTask
   extends SparkNomadTaskType("executor", "executor", EXECUTOR_MEMORY) {
@@ -72,10 +71,9 @@ private[spark] object ExecutorTask
       .map(Utils.splitCommandString).getOrElse(Seq.empty)
 
     task.addEnv("SPARK_EXECUTOR_OPTS", (extraJavaOpts ++ executorConf).mkString(" "))
-
     task.addEnv("SPARK_EXECUTOR_MEMORY", jvmMemory(conf, task))
 
-    val sparkLocalDirs = conf.getOption("spark.local.dir").getOrElse("/spark-local-dir")
+    val sparkLocalDirs = conf.getOption("spark.local.dir").getOrElse("/tmp")
     task.addEnv("SPARK_LOCAL_DIRS", sparkLocalDirs)
 
     // Have the executor give its allocation ID as its log URL

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
@@ -18,9 +18,10 @@
 package org.apache.spark.scheduler.cluster.nomad
 
 import com.hashicorp.nomad.apimodel.Task
+
+import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.internal.config.EXECUTOR_MEMORY
 import org.apache.spark.util.Utils
-import org.apache.spark.{SecurityManager, SparkConf}
 
 private[spark] object ExecutorTask
   extends SparkNomadTaskType("executor", "executor", EXECUTOR_MEMORY) {

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
@@ -75,7 +75,7 @@ private[spark] object ExecutorTask
 
     task.addEnv("SPARK_EXECUTOR_MEMORY", jvmMemory(conf, task))
 
-    task.addEnv("SPARK_LOCAL_DIRS", "${NOMAD_ALLOC_DIR}")
+    task.addEnv("SPARK_LOCAL_DIRS", "/shuffle")
 
     // Have the executor give its allocation ID as its log URL
     // The driver will lookup the actual log URLs

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTask.scala
@@ -75,7 +75,8 @@ private[spark] object ExecutorTask
 
     task.addEnv("SPARK_EXECUTOR_MEMORY", jvmMemory(conf, task))
 
-    task.addEnv("SPARK_LOCAL_DIRS", "/shuffle")
+    val sparkLocalDirs = conf.getOption("spark.local.dir").getOrElse("/spark-local-dir")
+    task.addEnv("SPARK_LOCAL_DIRS", sparkLocalDirs)
 
     // Have the executor give its allocation ID as its log URL
     // The driver will lookup the actual log URLs

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTaskGroup.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/ExecutorTaskGroup.scala
@@ -20,11 +20,10 @@ package org.apache.spark.scheduler.cluster.nomad
 import com.hashicorp.nomad.apimodel.TaskGroup
 
 import org.apache.spark.SparkConf
-import org.apache.spark.internal.config.SHUFFLE_SERVICE_ENABLED
-import org.apache.spark.scheduler.cluster.nomad.SparkNomadJob.CommonConf
+import org.apache.spark.internal.config.{SHUFFLE_SERVICE_ENABLED, SHUFFLE_SERVICE_PORT}
 
 private[spark] object ExecutorTaskGroup
-  extends SparkNomadTaskGroupType("executor", ExecutorTask, ShuffleServiceTask) {
+  extends SparkNomadTaskGroupType("executor", ExecutorTask) {
 
   def configure(
       jobConf: SparkNomadJob.CommonConf,
@@ -38,10 +37,8 @@ private[spark] object ExecutorTaskGroup
 
     val shuffleServicePortPlaceholder =
       if (conf.get(SHUFFLE_SERVICE_ENABLED)) {
-        val task = findOrAdd(group, ShuffleServiceTask)
-        Some(ShuffleServiceTask.configure(jobConf, conf, task, reconfiguring))
+        Some(conf.get(SHUFFLE_SERVICE_PORT).toString)
       } else {
-        find(group, ShuffleServiceTask).foreach(group.getTasks.remove)
         None
       }
 

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/NomadClusterSchedulerBackend.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/NomadClusterSchedulerBackend.scala
@@ -181,14 +181,7 @@ private[spark] class NomadClusterSchedulerBackend(
     driverEndpoint.ask[Boolean](RequestExecutors(requestedTotal, 0, Map.empty, Set.empty))
 
   override def doKillExecutors(executorIds: Seq[String]): Future[Boolean] = {
-    logWarning(
-      executorIds.mkString(
-        s"Ignoring request to kill ${executorIds.size} executor(s): ",
-        ",",
-        " (not yet implemented for Nomad)"
-      )
-    )
-    super.doKillExecutors(executorIds)
+    jobController.removeExecutors(executorIds)
   }
 
 }

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/NomadJobManipulator.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/NomadJobManipulator.scala
@@ -58,6 +58,10 @@ private[spark] class NomadJobManipulator(val nomad: NomadScalaApi, private var j
     }
   }
 
+  def stopAlloc(allocId: String): Unit = {
+    nomad.allocations.stop(allocId)
+  }
+
   def fetchLogUrlsForTask(allocId: String, task: String): Map[String, String] = {
     val allocation = nomad.allocations.info(allocId).getValue
     val node = nomad.nodes.info(allocation.getNodeId).getValue

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/NomadJobManipulator.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/NomadJobManipulator.scala
@@ -59,7 +59,11 @@ private[spark] class NomadJobManipulator(val nomad: NomadScalaApi, private var j
   }
 
   def stopAlloc(allocId: String): Unit = {
-    nomad.allocations.stop(allocId)
+    nomad.allocations.signal(allocId, "SIGINT")
+  }
+
+  def isAllocStopped(allocId: String): Boolean = {
+    nomad.allocations.info(allocId).getValue.getClientStatus != "running"
   }
 
   def fetchLogUrlsForTask(allocId: String, task: String): Map[String, String] = {


### PR DESCRIPTION
nomad-spark PR Summary
==============================

- updates Nomad Scala SDK to 0.9.7
- adds ability to stop a specific Nomad allocation
- implements the SchedulerBackend `removeExecutors` method to enable automatic downscaling

The logic to actually remove a Nomad allocation is somewhat convoluted because of a couple key limitations in the Nomad API.  It doesn't provide an atomic "stop a specific set of allocations and scale down" operation, so we are left with stopping each allocation and then separately scaling the executor group down by decreasing the executor task group count. However, we need to 1) wait for allocs to actually stop before decreasing the job count (or Nomad will remove other allocs for us instead) plus 2) the allocs we remove shouldn't immediately be replaced by Nomad.  Unfortunately, Nomad ignores the task group's configured restart policy when an allocation is stopped via Nomad's `allocation stop` operation.  To get around this we instead send a `SIGINT` to the allocation. The Spark executor's shutdown handler shuts itself down, and the container's restart delay is honored.  We wait for each allocation to be removed, and then lower the job count.


Checklist
==============================

Testing
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have manually verified that my code changes do the right thing.
* [x] I have run all tests and verified that my changes do not introduce any regressions.
* [ ] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions.
* [x] I have tested my code changes locally or against a cluster using an example Spark project.

Documentation
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have updated code comments where appropriate.
* [x] I have read `CONTRIBUTING.md` and have followed its guidance.