### PR TITLE
Enable different nomad auth tokens

### DIFF
--- a/resource-managers/nomad/src/main/scala/org/apache/spark/deploy/nomad/NomadClusterModeConf.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/deploy/nomad/NomadClusterModeConf.scala
@@ -72,7 +72,7 @@ private[spark] object NomadClusterModeConf {
 
   def apply(conf: SparkConf, command: ApplicationRunCommand): NomadClusterModeConf = {
 
-    val backendConf = NomadClusterManagerConf(conf, Some(command))
+    val backendConf = NomadClusterManagerConf(conf, submitMode = true, Some(command))
 
     // Fail fast if dynamic execution is enabled but the external shuffle service isn't
     // (otherwise we would create a Nomad job to run the driver, and it would fail to start)

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/deploy/nomad/NomadDryRun.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/deploy/nomad/NomadDryRun.scala
@@ -31,7 +31,7 @@ private[spark] object NomadDryRun extends Logging {
 
     val backendConf = conf.get("spark.submit.deployMode") match {
       case "cluster" => NomadClusterModeConf(conf, parseArguments(argStrings)).backend
-      case _ => NomadClusterManagerConf(conf, None)
+      case _ => NomadClusterManagerConf(conf, submitMode = false, None)
     }
 
     val NewJob(job) = backendConf.jobDescriptor

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/NomadClusterManager.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/NomadClusterManager.scala
@@ -43,7 +43,7 @@ private[spark] class NomadClusterManager extends ExternalClusterManager with Log
       masterURL: String,
       scheduler: TaskScheduler): SchedulerBackend = {
 
-    val clusterManagerConf = NomadClusterManagerConf(sc.conf, None)
+    val clusterManagerConf = NomadClusterManagerConf(sc.conf, false, None)
 
     logInfo(s"Will access Nomad API at ${clusterManagerConf.nomadApi.getAddress}")
     val api = NomadScalaApi(clusterManagerConf.nomadApi)


### PR DESCRIPTION
nomad-spark PR Summary
==============================

Creates two new spark conf options which allow a different token for the initial job submission and for use by the driver

Additional Details
==============================

Also creates backoff loop when talking to the nomad api to prevent unlimited calls

Checklist
==============================

Testing
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [X] I have manually verified that my code changes do the right thing.
* [X] have run all tests and verified that my changes do not introduce any regressions.
* [ ] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions.
* [X] I have tested my code changes locally or against a cluster using an example Spark project.

Documentation
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [X] I have updated code comments where appropriate.
* [X] I have read `CONTRIBUTING.md` and have followed its guidance.